### PR TITLE
Update sidebar_node.js

### DIFF
--- a/app/js/sidebar_node.js
+++ b/app/js/sidebar_node.js
@@ -39,12 +39,15 @@ jsloader(cnPath + "js/functions/settings.js");
 
 
 let CUSTOM_COLORS;
-
+const SETTING_THEME = 'jovi.color.theme';
 
 try {
-    var response = await api.fetchApi("/jovimetrix/config", { cache: "no-store" })
-    const CONFIG_CORE =  await response.json()
-    CUSTOM_COLORS = CONFIG_CORE?.user?.default?.color?.theme;
+    CUSTOM_COLORS = app.extensionManager.setting.get(SETTING_THEME) || {};
+    Object.keys(DEFAULT_THEME).forEach(key => {
+        if (!(key in CONFIG_THEME)) {
+            CONFIG_THEME[key] = DEFAULT_THEME[key];
+        }
+    });
 } catch (err) {
     console.log(err)
 }


### PR DESCRIPTION
Patches the sidebar to work with Jovi_Colorizer extension once again. Pulls title colors for node entries and colors them with said color entry in the sidebar.

![image](https://github.com/user-attachments/assets/e0fa5d86-7c0f-4362-914f-5772817afc52)

Only had to update where the data was loaded from since it is no longer on a route, but directly from the setting store via Comfy Core.

Cheers on the revival!